### PR TITLE
Fixes indents so injection lines up with templates

### DIFF
--- a/lib/generators/route.js
+++ b/lib/generators/route.js
@@ -61,7 +61,7 @@ var RouteGenerator = Generator.create({
 
         var end = (hasWildCard) ? '<Route' : '</Router>';
 
-        this.injectIntoFile(destpath, '\n' + content + '\n', '<Router', end);
+        this.injectIntoFile(destpath, '\n      ' + content + '\n      ', '<Router', end);
     }
 
 

--- a/lib/templates/route/route.js.jsx
+++ b/lib/templates/route/route.js.jsx
@@ -1,3 +1,3 @@
-<Route path='<%= url %>' component={ Component.<%= layout %> }>
-    <IndexRoute component={ Component.<%= templateName %> }/>
-</Route>
+      <Route path='<%= url %>' component={ Component.<%= layout %> }>
+          <IndexRoute component={ Component.<%= templateName %> }/>
+      </Route>


### PR DESCRIPTION
After running 

```
maka g:route route1
maka g:route route2
maka g:route route3
```

The routes.jsx file looks like

```jsx
Meteor.startup( () => {
  render(
    <Router history={ browserHistory }>
      <Route path='/' component={ Component.MasterLayout }>
          <IndexRoute component={ Component.Home }/>
      </Route>
      
      <Route path='/route1' component={ Component.MasterLayout }>
          <IndexRoute component={ Component.Route1 }/>
      </Route>
      
      <Route path='/route2' component={ Component.MasterLayout }>
          <IndexRoute component={ Component.Route2 }/>
      </Route>
      
      <Route path='/route3' component={ Component.MasterLayout }>
          <IndexRoute component={ Component.Route3 }/>
      </Route>
      <Route path="*" component={ Component.MasterLayout }>
          <IndexRoute component={ Component.NotFound }/>
      </Route>
    </Router>,
    document.getElementById( 'react-root' )
  );
});
```