### PR TITLE
Fix for --skip-template-css=false for client other than react

### DIFF
--- a/lib/generators/template.js
+++ b/lib/generators/template.js
@@ -94,15 +94,24 @@ Generator.create({
   }
   // Import the HTML and CSS
   if (config.engines.client !== 'react') {
-      this.injectAtBeginningOfFile(
-          pathToTemplate + "." + config.engines.js,
-          "import './" + this.fileCase(opts.resourceName) + "." + config.engines.html + "';\n" +
-          "import './" + this.fileCase(opts.resourceName) + "." + config.engines.css + "';"
-      );
+      if (config.template.css === 'true') {
+          this.injectAtBeginningOfFile(
+              pathToTemplate + "." + config.engines.js,
+              "import './" + this.fileCase(opts.resourceName) + "." + config.engines.html + "';\n" +
+              "import './" + this.fileCase(opts.resourceName) + "." + config.engines.css + "';"
+          );
+      }
+
+      if (config.template.css === 'false') {
+          this.injectAtBeginningOfFile(
+              pathToTemplate + "." + config.engines.js,
+              "import './" + this.fileCase(opts.resourceName) + "." + config.engines.html + "';"
+          );
+      }      
   }
 
 
-  if (CurrentConfig.get().template.css !== 'false') {
+  if (config.template.css !== 'false') {
     this.template(
       'template/template.css',
       pathToTemplate + '.css',
@@ -151,3 +160,4 @@ Generator.create({
   }
 
 });
+


### PR DESCRIPTION
If the project is created with client blaze and with flag --skip-template-css=true still import ./template.css line pesents in template.js file which raises an issue. This code fix the said problem.

Kindly merge the change to make the cli more robust and error free.

Thanks & Regards