### PR TITLE
Bug during setting default engines

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -58,7 +58,7 @@ function withValidation (configValue) {
     engines.js = defaultValue(engines.js, 'js');
     engines.css = defaultValue(engines.css, 'css');
     engines.client = defaultValue(engines.client, 'react');
-    engines.api = defaultValue(engines.apollo, 'none');
+    engines.api = defaultValue(engines.api, 'none');
 
     return configValue;
 }


### PR DESCRIPTION
There is a bug in setting default engine for api. The bugged engine used is graphql which should be api instead.